### PR TITLE
add sort material super command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botw-ist",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "homepage": "https://ist.itntpiston.app/",
   "private": true,
   "dependencies": {

--- a/src/core/SimulationState.ts
+++ b/src/core/SimulationState.ts
@@ -314,4 +314,9 @@ export class SimulationState {
 		this.pouch.swap(i,j);
 	}
 
+	public inaccuratelySortMaterials() {
+		this.pouch.inaccuratelySortMaterials();
+		this.syncGameDataWithPouch();
+	}
+
 }

--- a/src/core/command/ast/grammar.txt
+++ b/src/core/command/ast/grammar.txt
@@ -59,6 +59,7 @@ SuperCommand =>
  SuperCommandAddSlot        # ! add slot ... [from slot X]
  | SuperCommandRemoveSlot   # ! remove slot X
  | SuperCommandSwap         # ! swap i j
+ | SuperCommandSortMaterial # ! sort material
  | SuperCommandForCommand
 ---
 
@@ -92,6 +93,7 @@ CommandHas => <has> LiteralMaybeNot ValueValue OneOrMoreIdentifiers
 SuperCommandAddSlot => <!> <add> LiteralSlot ArgumentOneOrMoreItemsMaybeFromSlot
 SuperCommandRemoveSlot => <!> <remove> LiteralSlot Integer
 SuperCommandSwap => <!> <swap> Integer Integer
+SuperCommandSortMaterial => <!> <sort> LiteralMaterial
 
 ## Literals
 LiteralInitialize => <initialize> | <init>

--- a/src/core/command/parse.cmd.super.test.ts
+++ b/src/core/command/parse.cmd.super.test.ts
@@ -1,10 +1,17 @@
 import { createMockItems, createMockItemSearch } from "data/test";
 import { ItemStackArg } from "./ItemStackArg";
-import { SuperCommandAddSlot, SuperCommandSwap } from "./parse.cmd.super";
+import { SuperCommandAddSlot, SuperCommandSortMaterial, SuperCommandSwap } from "./parse.cmd.super";
 
 describe("core/command/parse.super !swap", ()=>{
 	it("parses", ()=>{
 		expect("!swap 5 8").toParseIntoCommand(undefined, new SuperCommandSwap(5, 8, []));
+	});
+
+});
+
+describe("core/command/parse.super !sort material", ()=>{
+	it("parses", ()=>{
+		expect("!sort material").toParseIntoCommand(undefined, new SuperCommandSortMaterial([]));
 	});
 
 });

--- a/src/core/command/parse.cmd.super.ts
+++ b/src/core/command/parse.cmd.super.ts
@@ -1,7 +1,7 @@
 import { SimulationState } from "core/SimulationState";
 import { arrayEqual } from "data/util";
 import { getSlotsToAdd, ItemStackArg } from "./ItemStackArg";
-import { ASTSuperCommandAddSlot, ASTSuperCommandSwap } from "./ast";
+import { ASTSuperCommandAddSlot, ASTSuperCommandSortMaterial, ASTSuperCommandSwap } from "./ast";
 import { AbstractProperCommand, Command } from "./command";
 import { parseASTInteger } from "./parse.basis";
 import { parseASTArgumentOneOrMoreItemsAllowAllMaybeFromSlot } from "./parse.clause.with.fromslot";
@@ -68,4 +68,26 @@ export const parseASTSuperCommandAddSlot: ParserItem<ASTSuperCommandAddSlot, Sup
 		([stacks, slot], codeBlocks)=>new SuperCommandAddSlot(stacks, slot, codeBlocks),
 		codeBlocks
 	);
+};
+
+export class SuperCommandSortMaterial extends AbstractProperCommand  {
+
+	constructor(codeBlocks: CodeBlockTree){
+		super(codeBlocks);
+	}
+	public execute(state: SimulationState): void {
+		state.inaccuratelySortMaterials();
+	}
+	public equals(other: Command): boolean {
+		return other instanceof SuperCommandSortMaterial;
+	}
+}
+
+export const parseASTSuperCommandSortMaterial: ParserSafe<ASTSuperCommandSortMaterial, SuperCommandSortMaterial> = (ast) => {
+	const codeBlocks: CodeBlockTree = [
+		codeBlockFromRange(ast.literal0, "keyword.super"),
+		codeBlockFromRange(ast.literal1, "keyword.super"),
+	];
+
+	return [new SuperCommandSortMaterial(codeBlocks), codeBlocks];
 };

--- a/src/core/command/parsev2.ts
+++ b/src/core/command/parsev2.ts
@@ -26,6 +26,7 @@ import {
 	isCommandWriteMetadata,
 	isSuperCommandAddSlot,
 	isSuperCommandForCommand,
+	isSuperCommandSortMaterial,
 	isSuperCommandSwap
 } from "./ast";
 import { CmdErr, Command, CommandHint, CommandNop, ErrorCommand } from "./command";
@@ -40,7 +41,7 @@ import { parseASTCommandReload } from "./parse.cmd.reload";
 import { parseASTCommandDnp, parseASTCommandDrop, parseASTCommandEat, parseASTCommandRemove, parseASTCommandRemoveAll } from "./parse.cmd.remove";
 import { parseASTCommandSave } from "./parse.cmd.save";
 import { parseASTCommandShoot } from "./parse.cmd.shoot";
-import { parseASTSuperCommandAddSlot, parseASTSuperCommandSwap } from "./parse.cmd.super";
+import { parseASTSuperCommandAddSlot, parseASTSuperCommandSortMaterial, parseASTSuperCommandSwap } from "./parse.cmd.super";
 import { parseASTCommandSyncGameData } from "./parse.cmd.sync";
 import { parseASTCommandEnterTrial, parseASTCommandExitTrial } from "./parse.cmd.trial";
 import { parseASTCommandWriteMetadata } from "./parse.cmd.write";
@@ -270,6 +271,9 @@ const parseASTTarget: ParserItem<ASTTarget, Command> = (ast, search) => {
 	}
 	if(isSuperCommandSwap(ast)){
 		return withNoError(parseASTSuperCommandSwap(ast));
+	}
+	if(isSuperCommandSortMaterial(ast)){
+		return withNoError(parseASTSuperCommandSortMaterial(ast));
 	}
 
 	if(isSuperCommandForCommand(ast)){

--- a/src/core/inventory/Slots.ts
+++ b/src/core/inventory/Slots.ts
@@ -177,4 +177,8 @@ export class Slots {
 		this.core.swap(i, j);
 	}
 
+	public inaccuratelySortMaterials() {
+		this.core.sortMaterials();
+	}
+
 }

--- a/src/core/inventory/SlotsCore.ts
+++ b/src/core/inventory/SlotsCore.ts
@@ -41,6 +41,17 @@ export class SlotsCore {
 		this.internalSlots[j] = temp;
 	}
 
+	public sortMaterials() {
+		stableSort(this.internalSlots, (a,b)=>{
+			const itemA = a.get().item;
+			const itemB = b.get().item;
+			if(itemA.type === ItemType.Material && itemB.type === ItemType.Material){
+				return itemA.sortOrder - itemB.sortOrder;
+			}
+			return 0;
+		});
+	}
+
 	// Used to decide if game data is synced with inventory
 	// Two Slots are equal if the ItemStacks equal, including metadata equality
 	public equals(other: SlotsCore): boolean {

--- a/src/core/inventory/VisibleInventory.ts
+++ b/src/core/inventory/VisibleInventory.ts
@@ -217,6 +217,10 @@ export class VisibleInventory implements DisplayableInventory{
 		this.slots.swap(i, j);
 	}
 
+	public inaccuratelySortMaterials() {
+		this.slots.inaccuratelySortMaterials();
+	}
+
 	// public countItems(type: ItemType, countAnyWeapon: boolean): number {
 	// 	// [confirmed] iTNTPiston: when mcount === 0, nothing is checked (only when =0)
 	// 	const mcount = this.getMCount();


### PR DESCRIPTION
Add `!sort material` command to sort materials

This is a super command. It does not strictly correspond to the sort functionality in game, especially if gamedata is not synced. Only used for exploratory purpose.