### PR TITLE
clone submodules in docker build anyway

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          submodules: true
       - uses: oven-sh/setup-bun@v2
       - uses: arduino/setup-task@v2
         with:

--- a/packages/server/Taskfile.yml
+++ b/packages/server/Taskfile.yml
@@ -4,21 +4,17 @@ includes:
   ecma:
     taskfile: ../mono-dev/task/ecma.yaml
     internal: true
-    optional: true
   app:
     taskfile: ../app
     dir: ../app
     internal: true
-    optional: true
   runtime-wasm:
     taskfile: ../runtime-wasm
     dir: ../runtime-wasm
     internal: true
-    optional: true
   docker:
     taskfile: ../mono-dev/task/docker.yaml
     internal: true
-    optional: true
 
 vars:
   DOCKER_IMAGE: pistonite/skybook-server


### PR DESCRIPTION
Not worth the extra config lines to save cloning submodules when building docker image in CI