### PR TITLE
Fixed float issues, bad test case

### DIFF
--- a/packages/blueflame/src/processor/instructions/ldp.rs
+++ b/packages/blueflame/src/processor/instructions/ldp.rs
@@ -96,16 +96,8 @@ impl Core<'_, '_, '_> {
         let loaded_val: i64 = match xt1 {
             RegisterType::XReg(_) => self.mem.mem_read_i64(address)?,
             RegisterType::WReg(_) => self.mem.mem_read_i32(address)? as i64,
-            RegisterType::SReg(_) => {
-                let val = self.mem.mem_read_f32(address)?;
-                self.cpu.write_reg(&xt1, &RegisterValue::SReg(val))?;
-                return Result::Ok(());
-            }
-            RegisterType::DReg(_) => {
-                let val = self.mem.mem_read_f64(address)?;
-                self.cpu.write_reg(&xt1, &RegisterValue::DReg(val))?;
-                return Result::Ok(());
-            }
+            RegisterType::SReg(_) => self.mem.mem_read_i32(address)? as i64,
+            RegisterType::DReg(_) => self.mem.mem_read_i64(address)?,
             _ => {
                 return Err(Error::InstructionError(String::from(
                     "Loading into non-general register type",
@@ -116,16 +108,8 @@ impl Core<'_, '_, '_> {
         let loaded_val: i64 = match xt2 {
             RegisterType::XReg(_) => self.mem.mem_read_i64(address + 8)?,
             RegisterType::WReg(_) => self.mem.mem_read_i32(address + 4)? as i64,
-            RegisterType::SReg(_) => {
-                let val = self.mem.mem_read_f32(address)? as f64;
-                self.cpu.write_reg(&xt2, &RegisterValue::HReg(val))?;
-                return Result::Ok(());
-            }
-            RegisterType::DReg(_) => {
-                let val = self.mem.mem_read_f64(address)?;
-                self.cpu.write_reg(&xt1, &RegisterValue::DReg(val))?;
-                return Result::Ok(());
-            }
+            RegisterType::SReg(_) => self.mem.mem_read_i32(address + 4)? as i64,
+            RegisterType::DReg(_) => self.mem.mem_read_i64(address + 8)?,
             _ => {
                 return Err(Error::InstructionError(String::from(
                     "Loading into non-general register type",

--- a/packages/blueflame/src/processor/instructions/scvtf.rs
+++ b/packages/blueflame/src/processor/instructions/scvtf.rs
@@ -58,7 +58,7 @@ pub fn simple_scvtf_test() -> anyhow::Result<()> {
         mem: &mut mem,
         proxies: &mut proxies,
     };
-    core.handle_string_command(&String::from("fmov s0, #4"))?;
+    core.handle_string_command(&String::from("mov s0, #4"))?;
     core.handle_string_command(&String::from("scvtf s0, s0"))?;
     assert_eq!(
         core.cpu.read_reg(&RegisterType::SReg(0)),

--- a/packages/blueflame/src/processor/mod.rs
+++ b/packages/blueflame/src/processor/mod.rs
@@ -409,7 +409,7 @@ impl Processor {
             RegisterType::SReg(_) => {
                 self.write_reg(
                     reg,
-                    &RegisterValue::SReg(f32::from_le_bytes((val as i32).to_le_bytes())),
+                    &RegisterValue::SReg(f32::from_bits(val as u32)),
                 )?;
                 Ok(())
             }

--- a/packages/blueflame/src/processor/mod.rs
+++ b/packages/blueflame/src/processor/mod.rs
@@ -407,7 +407,10 @@ impl Processor {
                 Ok(())
             }
             RegisterType::SReg(_) => {
-                self.write_reg(reg, &RegisterValue::SReg(val as f32))?;
+                self.write_reg(
+                    reg,
+                    &RegisterValue::SReg(f32::from_le_bytes((val as i32).to_le_bytes())),
+                )?;
                 Ok(())
             }
             RegisterType::WZR => Ok(()),

--- a/packages/blueflame/tests/game_data_iter_tests.rs
+++ b/packages/blueflame/tests/game_data_iter_tests.rs
@@ -7,12 +7,6 @@ use blueflame::{
     Core,
 };
 
-macro_rules! assert_delta {
-    ($x:expr, $y:expr, $d:expr) => {
-        assert!($x - $y < $d || $y - $x < $d);
-    };
-}
-
 #[test]
 fn test_one_simple_item() -> Result<(), Box<dyn Error>> {
     let data = std::fs::read("../test_files/program.blfm").unwrap();
@@ -180,7 +174,7 @@ fn test_food_items() -> Result<(), Box<dyn Error>> {
     assert_eq!(0, cook_data.sell_price);
     assert_eq!(0, cook_data.health_recover);
     assert_eq!(4, cook_data.effect_duration);
-    assert_delta!(4.0, cook_data.effect.1, f32::EPSILON);
+    assert_eq!(4.0, cook_data.effect.1);
 
     Ok(())
 }


### PR DESCRIPTION
Fixed an issue where ldp would only load one float register. Fixed an issue where write_gen_reg would implicitly perform scvtf conversion. Fixed an incorrect test case for scvtf.