### PR TITLE
runtime: update doc for save and improve save handling

### DIFF
--- a/packages/manual/src/SUMMARY.md
+++ b/packages/manual/src/SUMMARY.md
@@ -24,7 +24,7 @@
     - [Shop](./action/shop.md)
     - [Break Slots](./action/break_slots.md)
     - [Entangle](./action/entangle.md)
-    - [Action: Handling Saves]()
+    - [Save Files](./action/save.md)
     - [Action: Overworld Transform]()
     - [Action: Trials]()
     - [Action: Other]()

--- a/packages/manual/src/action/save.md
+++ b/packages/manual/src/action/save.md
@@ -1,0 +1,65 @@
+# Save Files
+
+In the game, you can manually save from the System menu, or the game can trigger
+auto-saves at various times. In the simulator, we simulate multiple save slots
+by having a *manual save* slot, and many *named save* slots. The idea
+is you will give a save file a name, so you can refer to the name when you need
+to reload it, just like you can remember which save slot in the game is the file you want to reload.
+
+## Syntax
+
+> `save` <br>
+> `save-as FILE-NAME` <br>
+> `reload` <br>
+> `reload FILE-NAME` <br>
+> `close-game` <br>
+> `new-game` <br>
+
+Example
+```skybook
+# Save to the manual save slot
+save
+# Save to a named save called `my-save`
+save-as my-save
+# Reload the manual save
+reload
+# Reload a named save
+reload my-save
+```
+
+## Inspecting Save Files in the App
+Amongst other things, a save file for the game includes a copy of savable flags in GameData,
+which contains the items in the save. Therefore, the simulator displays save files
+similar to how it displays GameData.
+
+Using the `Save Files` extension, you will see a list of save names available at the
+current step in the simulation. Clicking on a save will then display the items in that save.
+
+Note that you can inspect saves even on steps where the game isn't open.
+
+## New Game and Restarting the Game
+The <skyb>reload</skyb> and <skyb>new-game</skyb> are the only 2 commands that can
+restart the game after it's closed, either due to crash or was manually closed.
+
+Currently, <skyb>new-game</skyb> is implemented as reloading an imaginary save
+made at new game. The implementation is as follows:
+
+| Game State | Action | Implementation |
+|-|-|-|
+| Running | <skyb>reload</skyb> | Reload the save |
+| Running | <skyb>new-game</skyb> | Reload the "new game" save |
+| Closed | <skyb>reload</skyb> | Start a new game, then reload the save |
+| Closed | <skyb>new-game</skyb> | Start a new game |
+
+This is not 100% accurate to what the game does, but should be close enough.
+
+## Simulating the System menu
+<skyb>save</skyb> (and <skyb>save-as</skyb> if in inventory) will currently automatically <skyb>unhold</skyb>
+the currently held items, similar to how the game does that when you switch to the System menu.
+
+## Detail
+
+- <skyb>save</skyb> requires [`Inventory`](../user/screen_system.md) screen
+- <skyb>save-as</skyb> can be performed in either `Inventory` or `Overworld`
+- <skyb>reload</skyb> requires `Inventory` screen if the game is running.
+  - <skyb>new-game</skyb> is similar, see implementation detail above.

--- a/packages/manual/src/user/systems.md
+++ b/packages/manual/src/user/systems.md
@@ -7,6 +7,6 @@ also may not be worth to emulate since a simulation is good enough.
 The systems that are involved in the simulator include:
 - Inventory
 - GameData
-- Saves
+- [Saves](../action/save.md)
 - [Screens](./screen_system.md)
 - [Overworld](./overworld_system.md)

--- a/packages/runtime/src/sim/actions/common.rs
+++ b/packages/runtime/src/sim/actions/common.rs
@@ -11,6 +11,9 @@ use crate::sim;
 
 macro_rules! switch_to_overworld_or_stop {
     ($ctx:ident, $sys:ident, $errors:ident, $command:literal) => {
+        $crate::sim::actions::common::switch_to_overworld_or_stop!($ctx, $sys, $errors, $command, {})
+    };
+    ($ctx:ident, $sys:ident, $errors:ident, $command:literal, $block:block) => {
         if !$sys
             .screen
             .transition_to_overworld($ctx, &mut $sys.overworld, false, $errors)?
@@ -19,6 +22,7 @@ macro_rules! switch_to_overworld_or_stop {
                 "failed to auto-switch to overworld for {} command",
                 $command
             );
+            $block
             return Ok(());
         }
     };
@@ -27,6 +31,9 @@ pub(crate) use switch_to_overworld_or_stop;
 
 macro_rules! switch_to_inventory_or_stop {
     ($ctx:ident, $sys:ident, $errors:ident, $command:literal) => {
+        $crate::sim::actions::common::switch_to_inventory_or_stop!($ctx, $sys, $errors, $command, {})
+    };
+    ($ctx:ident, $sys:ident, $errors:ident, $command:literal, $block:block) => {
         if !$sys
             .screen
             .transition_to_inventory($ctx, &mut $sys.overworld, false, $errors)?
@@ -35,6 +42,7 @@ macro_rules! switch_to_inventory_or_stop {
                 "failed to auto-switch to inventory for {} command",
                 $command
             );
+            $block
             return Ok(());
         }
     };

--- a/packages/runtime/src/sim/actions/hold_items.rs
+++ b/packages/runtime/src/sim/actions/hold_items.rs
@@ -134,6 +134,14 @@ pub fn unhold(
     if !sys.screen.current_screen().is_inventory_or_overworld() {
         super::switch_to_overworld_or_stop!(ctx, sys, errors, "UNHOLD");
     }
+    unhold_internal(ctx, sys)
+}
+
+/// Unhold without screen checks
+pub fn unhold_internal(
+    ctx: &mut sim::Context<&mut Cpu2>,
+    sys: &mut sim::GameSystems,
+) -> Result<(), processor::Error> {
     // we don't check if the player is currently holding anything,
     // as it requires reading PMDM to check if it's holding in the pause menu
     linker::unhold_items(ctx.cpu())?;

--- a/packages/runtime/src/sim/actions/mod.rs
+++ b/packages/runtime/src/sim/actions/mod.rs
@@ -15,6 +15,8 @@ mod sell_items;
 pub use sell_items::*;
 mod entangle;
 pub use entangle::*;
+mod save;
+pub use save::*;
 
 mod break_slot;
 pub use break_slot::*;

--- a/packages/runtime/src/sim/actions/save.rs
+++ b/packages/runtime/src/sim/actions/save.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use blueflame::game::gdt;
+use blueflame::memory::proxy;
+use blueflame::processor::{self, Cpu2};
+
+use crate::error::ErrorReport;
+use crate::sim;
+
+/// Save the game
+///
+/// Since the save system extend beyond the game (you can access them
+/// even when the game is closed), the easist way to handle
+/// this is by using a channel to send the save back to the runtime thread
+/// from the executor thread
+pub fn save(
+    ctx: &mut sim::Context<&mut Cpu2>,
+    sys: &mut sim::GameSystems,
+    errors: &mut Vec<ErrorReport>,
+    allow_overworld: bool,
+    send: oneshot::Sender<Option<Arc<gdt::TriggerParam>>>,
+) -> Result<(), processor::Error> {
+    if allow_overworld {
+        if !sys.screen.current_screen().is_inventory_or_overworld() {
+            super::switch_to_overworld_or_stop!(ctx, sys, errors, "SAVE", {
+                if send.send(None).is_err() {
+                    log::error!("failed to send save data to runtime main thread");
+                }
+            });
+        }
+    } else {
+        super::switch_to_inventory_or_stop!(ctx, sys, errors, "SAVE", {
+            if send.send(None).is_err() {
+                log::error!("failed to send save data to runtime main thread");
+            }
+        });
+    }
+    // switching to system tab to save will automatically unhold items
+    // (if in holding state. if in PE drop hold state then it would not unhold)
+    if sys.screen.current_screen().is_inventory() && sys.screen.holding_in_inventory {
+        super::hold_items::unhold_internal(ctx, sys)?;
+    }
+    let gdt_ptr = gdt::trigger_param_ptr(ctx.cpu().proc.memory())?;
+    let proc = &ctx.cpu().proc;
+    proxy! { let gdt = *gdt_ptr as trigger_param in proc };
+    if send.send(Some(Arc::new(gdt.clone()))).is_err() {
+        log::error!("failed to send save data to runtime main thread");
+    }
+    Ok(())
+}


### PR DESCRIPTION
enforce screen for `save` and `save-as`