### PR TITLE
Fix typos, add/modify punctuation

### DIFF
--- a/packages/manual/src/action/break_slots.md
+++ b/packages/manual/src/action/break_slots.md
@@ -4,7 +4,7 @@
 to enable IST. See [Inventory Slot Transfer](../ist/index.md) for more info.
 
 You can either break slots by simulating actions, like what you do in the game,
-or use the <skyb>!break</skyb> supercommand to directly edit the memory
+or use the <skyb>!break</skyb> supercommand to directly edit the memory.
 
 ## Arrowless Offset
 
@@ -14,7 +14,7 @@ References for commands used for Arrowless Offset:
 - [`sell`](./sell.md)
 ```
 
-The most commonly used method of breaking slots is known as `Arrowless Offset`.
+The most commonly used method of breaking slots is known as `Arrowless Offset`,
 which requires a shield, a one-handed weapon and a shop keeper and can break up to 5 slots at once:
 
 - Enter the [`Smuggle State`](./material.md#smuggle-state-for-arrowless-offset)
@@ -22,7 +22,8 @@ which requires a shield, a one-handed weapon and a shop keeper and can break up 
 - Sell all the items from slots that are being held
 - Close the dialog
 
-Example script for Arrowless Offset in the simulator
+Example script for Arrowless Offset in the simulator:
+
 ```skybook
 get 2 shroom 2 pepper 1 banana
 :smug hold 1 shroom 1 pepper
@@ -33,7 +34,7 @@ close-dialog
 ## Hold Smuggle Offset
 
 ```admonish todo
-Menu Overload functionality is WIP
+Menu Overload functionality is WIP.
 ```
 
 ## Fairy Offset
@@ -46,4 +47,4 @@ drop; # drop the held fairy
 ```
 
 ## By Magic
-See [Low Level Operations](./low_level.md#generate-broken-slots)
+See [Low Level Operations](./low_level.md#generate-broken-slots).

--- a/packages/manual/src/action/entangle.md
+++ b/packages/manual/src/action/entangle.md
@@ -4,10 +4,10 @@ Activate [Prompt Entanglement](../ist/pe.md) and perform actions on a slot using
 from another.
 
 - <skyb>entangle</skyb> activates PE and sets the target item
-- <skyb>:targeting</skyb> changes the target item, or allow you to target empty slots
+- <skyb>:targeting</skyb> changes the target item, or allows you to target empty slots
 
 ```admonish warning
-PE is not 100% accurate
+PE is not 100% accurate.
 ```
 
 ## Syntax
@@ -73,18 +73,18 @@ drop pot-lid # will hold the roasted endura carrot
 
 Since it can be redundant to activate, then target the same item,
 <skyb>entangle</skyb> will also target the item by default.
-The command above can be shortened as
+The command above can be shortened as:
+
 ```skybook
 entangle roasted-endura-carrot
 drop pot-lid # will hold the roasted endura carrot
 ```
 
-However, sometimes it might be cleared to write it as <skyb>entangle</skyb> then <skyb>:targeting</skyb>.
+However, sometimes it might be clearer to write it as <skyb>entangle</skyb> then <skyb>:targeting</skyb>.
 For example, during speedrun, it's usually faster to <skyb>entangle</skyb>
 the source item, to skip resetting the prompt, which means the item to setup
 the <skyb>entangle</skyb> is different from the item to target.
 However, it's up to your preference how to write the command.
 
 The effect of <skyb>:targeting</skyb> will only last until the next command,
-but you can use multiple <skyb>:targeting</skyb> within the same <skyb>entangle</skyb>
-
+but you can use multiple <skyb>:targeting</skyb> within the same <skyb>entangle</skyb>.

--- a/packages/manual/src/action/equip.md
+++ b/packages/manual/src/action/equip.md
@@ -3,7 +3,7 @@
 Operations on equipments in inventory.
 
 - <skyb>equip</skyb> and <skyb>unequip</skyb> changes the equipped status.
-- <skyb>drop</skyb> drops the equipment from the inventory
+- <skyb>drop</skyb> drops the equipment from the inventory.
 
 ## Syntax
 
@@ -12,7 +12,7 @@ Operations on equipments in inventory.
 > `drop` [`CONTRAINED_ITEM_LIST`](../user/syntax_item.md) <br>
 
 Annotations:
-  - [`:dpad`](#change-equipments) - Use the DPad menu instead of inventory menu to change equipments
+  - [`:dpad`](#change-equipments) - Use the DPad menu instead of inventory menu to change equipments.
 
 ## Change equipments
 Example
@@ -83,7 +83,7 @@ and cannot be used to unequip arrows.
 
 ## Dropping Equipments from Inventory
 Use the <skyb>drop</skyb> command to drop equipments, which deletes the item in inventory,
-and spawn the item in overworld when the inventory is closed.
+and spawns the item in overworld when the inventory is closed.
 
 The game has a limitation on how many weapons can be dropped, but this is not implemented in the simulator.
 

--- a/packages/manual/src/action/flags.md
+++ b/packages/manual/src/action/flags.md
@@ -1,7 +1,7 @@
 # Game Flags
 
 Change flag values in GameData (GDT), such as number of upgrade slots,
-if a tab is discovered, and quest flags.
+whether a tab is discovered, and quest flags.
 
 - <skyb>:slots</skyb> can be used to change the flag value
   for how many slots are available for Weapons, Bows and Shields
@@ -22,6 +22,7 @@ Moreover, <skyb>!set-gdt</skyb> can be used to set *any* GDT flag.
 according to the category that is specified.
 
 Examples:
+
 ```skybook
 # sets the number of weapon slots to 20 (singular/plural forms are both accepted)
 :slots [weapon=20]
@@ -38,6 +39,7 @@ Examples:
 ## Discovered Tabs
 <skyb>:discovered</skyb> edits the `IsOpenItemCategory` flag array.
 The category is parsed in the same way as [item categories](../user/syntax_item.md#name).
+
 With a few minor differences:
 - `arrow` and `arrows` are allowed, and they are the same as `bow`/`bows`
 - Specific armor subtype (Upper/Lower/Head) is not allowed, use `armor`/`armors` instead
@@ -55,7 +57,7 @@ Examples
 
 ```admonish note
 When changing a tab from undiscovered to discovered, the inventory will not automatically
-update until it is changed (i.e. when `updateInventoryInfo()` is called again)
+update until it is changed (i.e. when `updateInventoryInfo()` is called again).
 ```
 
 ## Any Flag
@@ -75,6 +77,7 @@ The meta is where you specify the value. First, you need to specify one of the p
 - `vec3f` (alias: `vector3f`)
 
 For non-vector types, the meta value is the value to set. Examples:
+
 ```skybook
 # Make Master Sword stay in True Form
 !set-gdt <Open_MasterSword_FullPower>[bool=true]
@@ -82,7 +85,8 @@ For non-vector types, the meta value is the value to set. Examples:
 !set-gdt <MasterSwordRecoverTime>[f32=10.0]
 ```
 
-For array values, use the `index` property to specify the array index (alias: `i` or `idx`)
+For array values, use the `index` property to specify the array index (alias: `i` or `idx`):
+
 ```skybook
 # Set the first item in GDT to Travel Medallion
 # String values work without quotes if it only contains alphabetical characters and _ or -
@@ -90,7 +94,7 @@ For array values, use the `index` property to specify the array index (alias: `i
 # Set the value of the 20-th item in GDT (0-indexed) to 1000
 !set-gdt <PorchItem_Value1>[s32=1000, idx=20]
 # Set the modifier value of the 10-th shield in GDT (0-indexed) to 1000
-!set-gdt <PorchShield_ValueSp>[s32=1000, idx=20]
+!set-gdt <PorchShield_ValueSp>[s32=1000, idx=10]
 ```
 
 For vector values, instead of specifying the value with the `vec2f` or `vec3f` key,
@@ -105,5 +109,5 @@ are specified will be changed
 ```
 
 ```admonish note
-Integer values for vector components are automatically converted to 32-bit IEEE-754 floats
+Integer values for vector components are automatically converted to 32-bit IEEE-754 floats.
 ```

--- a/packages/manual/src/action/get.md
+++ b/packages/manual/src/action/get.md
@@ -37,7 +37,7 @@ You cannot <skyb>pick-up</skyb> items that aren't on the ground. Use <skyb>get</
 instead.
 
 ## Buying from NPC
-Normally, you buy items in this game by talking to the item directly in the overworld.
+Normally, you buy items in this game by "talking" to the item directly in the overworld.
 Certain NPCs are exceptions, such as Beedle, Travelling Merchants, and Kilton.
 For these NPCs, you need to talk to them, and buy from a separate dialog.
 
@@ -48,11 +48,11 @@ To talk to an NPC and buy, use the <skyb>talk-to</skyb> command.
 ```skybook
 talk-to beedle    # Opens Shop Buying screen
 buy 5 arrows
-shoot             # Automatically closes the screen and shoot arrow
+shoot             # Automatically close the screen and shoot arrow
                   # To manually close the screen, use `untalk` or `close-dialog`
 ```
 
-To sell, them buy within the same dialog sequence, use the <skyb>:same-dialog</skyb>
+To sell, then buy within the same dialog sequence, use the <skyb>:same-dialog</skyb>
 annotation
 ```skybook
 sell ruby                 # Opens Shop Selling screen
@@ -89,7 +89,8 @@ unpause
 # Now the 2 shrooms will drop to the ground because of how the smuggle works
 ```
 
-You can also use this feature to explicity annotate optimizations for speedruns
+You can also use this feature to explicitly annotate optimizations for speedruns.
+
 ```skybook
 :pause-during get zora-armor; equip zora-armor
 ```

--- a/packages/manual/src/action/low_level.md
+++ b/packages/manual/src/action/low_level.md
@@ -1,10 +1,10 @@
 # Low Level Operations
 
 These supercommands allow directly editing memory for prototyping or testing,
-or to workaround limitation of the simulator.
+or to workaround limitations of the simulator.
 
 ```admonish danger
-Because these commands edit memory directly, instead of mimic what the game does,
+Because these commands edit memory directly, instead of mimicking what the game does,
 they could be very inconsistent with the behavior of the game sometimes!
 
 Make sure you read the doc carefully before using them!
@@ -12,7 +12,7 @@ Make sure you read the doc carefully before using them!
 
 ## Syntax
 
-Examples are available at each section below
+Examples are available at each section below.
 
 [Generate Broken Slots](#generate-broken-slots)
 > `!break X slots` <br>
@@ -32,7 +32,7 @@ Examples are available at each section below
 
 ```admonish tip
 The simulator supports breaking slots using actions you would
-do in-game. See [Break Slots](./break_slots.md). 
+do in-game. See [Break Slots](./break_slots.md).
 ```
 
 The <skyb>!break</skyb> command edits `mCount` of `list1` and `list2` directly
@@ -48,13 +48,14 @@ The <skyb>!init</skyb> and <skyb>!add-slot</skyb> command will directly
 push a new item from `list2` to `list1`, and set the memory according
 to the item you specified. This will bypass ALL checks for adding item to inventory.
 
-Note that it will still prevent adding item when `list2.mCount` is `0`.
+Note that it will still prevent adding items when `list2.mCount` is `0`.
 
 Furthermore, <skyb>!init</skyb> will reset `list1` and `list2` to the initial state
 (where `list2` has `420` items and `list1` has `0`). This means all broken slots
 will be cleared as well.
 
-Example
+Example:
+
 ```skybook
 # setting items without sorting
 !init 1 slate 1 glider 5 apples
@@ -75,12 +76,13 @@ for the corresponding category.
 ## Forcefully Remove Items
 
 The <skyb>!remove</skyb> supercommand lets you forcefully delete items from the inventory:
-- For Arrows, Materials, Foods, and Key Items, the value of the slot will decrease by the amount
+- For Arrows, Materials, Foods, and Key Items, the value of the slot will decrease by the amount.
 - For the rest, the amount in the command corresponds to how many slots of this item you want to remove.
 
-Inventory and GameData state are fixed and synced afterward;
+Inventory and GameData state are fixed and synced afterward.
 
-Examples
+Example:
+
 ```skybook
 !remove all cores
 ```
@@ -100,7 +102,8 @@ are fixed and synced afterward.
 
 Currently, changing the `ingredients` is not supported.
 
-Examples
+Examples:
+
 ```skybook
 # Change the value of the Master Sword to 0
 # NOTE THAT THIS DOES NOT BREAK IT 
@@ -125,7 +128,8 @@ for Weapon/Bow/Arrow/Shield.
 The <skyb>!swap</skyb> supercommands targets 2 items, and swap their nodes in the list.
 Inventory and GameData state are fixed and synced afterward.
 
-Examples
+Examples:
+
 ```skybook
 # Swap the first apple stack and the first banana stack
 !swap apple and banana

--- a/packages/manual/src/action/material.md
+++ b/packages/manual/src/action/material.md
@@ -4,9 +4,9 @@ Performing actions on materials in the inventory. Some actions
 may apply to non-materials.
 
 - <skyb>hold</skyb> command performs the "hold" prompt.
-- <skyb>unhold</skyb> command stops holding in inventory, or put away the items in overworld
-- <skyb>drop</skyb> command drops currently held items, or hold and drop new items
-- <skyb>dnp</skyb> command is a shorthand for <skyb>drop</skyb> and [`pick-up`](./get.md)
+- <skyb>unhold</skyb> command stops holding in inventory, or put away the items in overworld.
+- <skyb>drop</skyb> command drops currently-held items, or hold and drop new items.
+- <skyb>dnp</skyb> command is a shorthand for <skyb>drop</skyb> and [`pick-up`](./get.md).
 - <skyb>eat</skyb> command performs the "eat" prompt.
 
 ## Syntax
@@ -37,12 +37,14 @@ The <skyb>:smug</skyb> annotation can be used to activate the item smuggle
 state required for `Arrowless Offset` for the next <skyb>hold</skyb> command, which is when the held materials are attached
 to Link's hand instead of being held in front of him.
 
-To do this in the simulator, put <skyb>:smug</skyb> right before the <skyb>hold</skyb> command
+To do this in the simulator, put <skyb>:smug</skyb> right before the <skyb>hold</skyb> command.
+
 ```skybook
 :smug
 hold 2 shrooms
 # Now you are in Overworld, and held items are attached to Link's hand
 ```
+
 You can also put <skyb>:smug hold</skyb> on the same line (which sounds like *smuggled*, hehe).
 
 To do this in the game, you need:
@@ -54,7 +56,7 @@ To perform this:
 2. Hold the `ZL` button
 3. Hold items from up to 5 slots
 4. Switch to a one-handed weapon
-   - Switch to another or to something else and back if you are already equipping a one-handed weapon
+   - Switch to another one-handed weapon, or to something else and back if you are already equipping a one-handed weapon
 5. Jump and let go of `ZL` button, after landing, when the shield is to Link's side,
    unequip the shield
 
@@ -68,7 +70,7 @@ generate offsets. In game, you can do this by either:
 
 ```admonish tip
 The <skyb>drop</skyb> is also used for dropping equipments, which has
-a slightly different semantic. The description here only applies to materials
+a slightly different semantic. The description here only applies to materials.
 ```
 
 When using <skyb>drop</skyb> without any items, it means to drop
@@ -86,8 +88,8 @@ the same items. Note that dropped items will not despawn after <skyb>pick-up</sk
 ## Detail
 
 - <skyb>hold</skyb> requires [`Inventory` screen](../user/screen_system.md),
-  and you can only hold a maximum of 5 items
+  and you can only hold a maximum of 5 items.
 - <skyb>drop</skyb> requires [`Overworld` screen](../user/screen_system.md)
-  when dropping held items. When a list of items is specified. It may switch
-  screens multiple times to facilitate the action
+  when dropping held items. When a list of items is specified, it may switch
+  screens multiple times to facilitate the action.
 - Certain actions are not possible when you are holding items.

--- a/packages/manual/src/action/overworld.md
+++ b/packages/manual/src/action/overworld.md
@@ -1,10 +1,10 @@
 # Overworld Operations
 
-Things you can do in the overworld
+Things you can do in the overworld:
 
 - <skyb>use</skyb> command uses and decreases durability of equipments,
-  or can be used to remove items while in the overworld, e.g. <skyb>use fairy</skyb>
-- <skyb>shoot</skyb> is an alias of <skyb>use bow</skyb>
+  or can be used to remove items while in the overworld, e.g. <skyb>use fairy</skyb>.
+- <skyb>shoot</skyb> is an alias of <skyb>use bow</skyb>.
 - <skyb>:overworld drop</skyb> command drops equipped equipments.
 
 ## Syntax
@@ -21,12 +21,12 @@ Annotations:
 ## Using Equipments
 
 To <skyb>use</skyb> an equipped weapon, you can either specify the category,
-or the item name (given the item is equipped)
+or the item name (given the item is equipped).
 
 ```skybook
-# Use the currently equipped weapon to hit something
+# Use the currently-equipped weapon to hit something
 use weapon
-# Use the currently equipped weapon to hit something 5 times
+# Use the currently-equipped weapon to hit something 5 times
 use weapon 5 times
 # Shoot with Royal Bow. Royal Bow must be the currently equipped bow
 use royal-bow
@@ -35,7 +35,7 @@ shoot
 ```
 
 The <skyb>:per-use</skyb> annotation changes how much durability is consumed
-per use. The default is `100`
+per use. The default is `100`.
 
 ```skybook
 # Bombing the shield takes 30 durability off
@@ -51,7 +51,7 @@ Special cases:
 ## Using Non-equipments
 
 When the item specified for <skyb>use</skyb> is not an equipment,
-it will attempt to remove the item instead. The only legitmate use
+it will attempt to remove the item instead. The only legitimate use
 of this is <skyb>use fairy</skyb>. However, the simulator will permit
 any item to be used this way.
 
@@ -63,13 +63,13 @@ hold fairy; use fairy; drop
 ## Dropping the Overworld Equipment
 
 ```admonish todo
-This command is WIP
+This command is WIP.
 ```
 In some cases, you can drop the equipment in the overworld without interacting
-with the inventory, for example when getting shocked.
+with the inventory; for example, when getting shocked.
 
 TODO
 
 ## Detail
 
-- <skyb>use</skyb> requires [`Overworld`](../user/screen_system.md)
+- <skyb>use</skyb> requires [`Overworld`](../user/screen_system.md).

--- a/packages/manual/src/action/save.md
+++ b/packages/manual/src/action/save.md
@@ -1,14 +1,14 @@
 # Save Files
 
-Handling game's running and closed state, and simulation of save files
+Handling game's running and closed state, and simulation of save files:
 
-- <skyb>save</skyb> command saves to the *manual save* slot
+- <skyb>save</skyb> command saves to the *manual save* slot.
 - <skyb>save-as file-name</skyb> command saves to a *named save* slot.
     You can later reload this save by its name. This is used to simulate auto-saves,
     but you can have unlimited number of them.
-- <skyb>reload</skyb> command reloads a manual or named save
-- <skyb>new-game</skyb> reloads an imaginary save with the state of a new game
-- <skyb>close-game</skyb> closes the game
+- <skyb>reload</skyb> command reloads a manual or named save.
+- <skyb>new-game</skyb> reloads an imaginary save with the state of a new game.
+- <skyb>close-game</skyb> closes the game.
 
 ## Syntax
 
@@ -24,6 +24,7 @@ instead of `-`), or a quoted string. Spaces and non-alphabetical characters are 
 allowed in quoted names, like <skyb>"Outside of Shrine"</skyb> or <skyb>"神庙外"</skyb>.
 
 Example
+
 ```skybook
 # Save to the manual save slot
 save
@@ -67,7 +68,7 @@ the currently held items, similar to how the game does that when you switch to t
 
 ## Detail
 
-- <skyb>save</skyb> requires [`Inventory`](../user/screen_system.md) screen
-- <skyb>save-as</skyb> can be performed in either `Inventory` or `Overworld`
+- <skyb>save</skyb> requires [`Inventory`](../user/screen_system.md) screen.
+- <skyb>save-as</skyb> can be performed in either `Inventory` or `Overworld`.
 - <skyb>reload</skyb> requires `Inventory` screen if the game is running.
   - <skyb>new-game</skyb> is similar, see implementation detail above.

--- a/packages/manual/src/action/sell.md
+++ b/packages/manual/src/action/sell.md
@@ -7,6 +7,7 @@ or trading away Spirit Orbs or Korok Seeds.
 > `sell` [`CONSTRAINED_ITEM_LIST`](../user/syntax.md) <br>
 
 Example
+
 ```skybook
 talk-to beedle
 sell all shroom all pepper
@@ -14,4 +15,4 @@ sell all shroom all pepper
 close-dialog
 ```
 
-Also see [Buy](./get.md)
+Also see [Buy](./get.md).

--- a/packages/manual/src/developer/contributing/index.md
+++ b/packages/manual/src/developer/contributing/index.md
@@ -4,7 +4,7 @@
 This section contains important information for contributing for the project.
 You should read everything here before contributing.
 
-Please also read the [`mono-dev` Contributing Guidelines](https://mono.pistonite.dev/pr_guidelines.html)
+Please also read the [`mono-dev` Contributing Guidelines](https://mono.pistonite.dev/pr_guidelines.html).
 ```
 ```admonish danger
 The repository must not contain any assets or data from BOTW, or any file
@@ -12,7 +12,7 @@ derived from assets or data from the game. PRs containing such files
 will be closed.
 
 Please reach out to me if you want to add something that depends on
-the game files
+the game files.
 ```
 ```admonish tip
 The project development is on [GitHub](https://github.com). You will need a GitHub

--- a/packages/manual/src/developer/contributing/run.md
+++ b/packages/manual/src/developer/contributing/run.md
@@ -14,21 +14,21 @@ You can also `cd` to the package and execute the task:
 
     cd packages/app
     task dev
-
-
 ```
 
 
 ## Web Application
 ```admonish warning
 Running the web app locally requires Secure Origin, which means either running from `localhost`
-or setting up HTTPS, see [here](https://mono.pistonite.dev/standard/setup_https.html)
+or setting up HTTPS, see [here](https://mono.pistonite.dev/standard/setup_https.html).
 ```
 
 To run the web application:
+
 ```
 task exec -- app:dev
 ```
+
 The UI will automatically reload as you make changes.
 
 Note that DirectLoad will not work when running the application locally since
@@ -36,25 +36,31 @@ it's a server feature.
 
 ## Manual
 To run the manual (this website):
+
 ```
 task exec -- manual:dev
 ```
-The manual will automatically reload when making changes
+
+The manual will automatically reload when making changes.
 
 ## Server
 ```admonish warning
 Currently, running the server locally also requires building the runtime as
-part of the assets, which requires a dump of the game to build
+part of the assets, which requires a dump of the game to build.
 ```
 
-To run the server, first build and pull the application assets locally
+To run the server, first build and pull the application assets locally:
+
 ```
 task exec -- server:pull-local
 ```
-Then the dev workflow can be started with
+
+Then the dev workflow can be started with:
+
 ```
 task exec -- server:dev
 ```
+
 Changes in the server code will reload the server automatically. However,
 changes in the client code requires re-running the client build and restarting
-the server (sometimes)
+the server (sometimes).

--- a/packages/manual/src/developer/contributing/runtime.md
+++ b/packages/manual/src/developer/contributing/runtime.md
@@ -37,6 +37,7 @@ This will also produce `program-mini.bfi`.
 
 Once you have the mini image, you can now make changes to the runtime packages,
 and rebuild the WASM package:
+
 ```
 cd packages/runtime-wasm
 task build

--- a/packages/manual/src/developer/contributing/setup.md
+++ b/packages/manual/src/developer/contributing/setup.md
@@ -15,12 +15,13 @@ to setup the required tools:
 - Task
 - Magoo
 
-Coreutils is required for Windows development
+Coreutils is required for Windows development.
 ```
 
 ## Clone repository and one-time setup
 
-Run the following commands
+Run the following commands:
+
 ```
 git clone git@github.com:Pistonite/botw-ist --depth 1
 cd botw-ist
@@ -46,6 +47,7 @@ This will:
 After pulling, you need to update the repo locally to sync tools to the latest state.
 
 Run:
+
 ```
 task install
 ```
@@ -64,7 +66,8 @@ To build the Runtime, you need to either:
   and put the image file at `packages/runtime-tests/data/program-mini.bfi`.
   This will use whatever image you provide as the default runtime image.
 
-Now, you can build the runtime WASM module
+Now, you can build the runtime WASM module:
+
 ```
 task exec runtime-wasm:build
 ```

--- a/packages/manual/src/developer/contributing/testing.md
+++ b/packages/manual/src/developer/contributing/testing.md
@@ -14,13 +14,13 @@ When there are formatting issues, `task exec -- XXX:fix` can automatically fix t
 
 ### `skybook-api` modification checks
 If you changed code that affects the generated `skybook-api` code, you need
-to commit those changes to git for `skybook-api` checks to pass
+to commit those changes to git for `skybook-api` checks to pass.
 
 ### `localization` checks
 Certain changes require adding keys to localization (e.g. new error types).
 Please reach out to me for adding localizations.
 
-The modification check also requires the changes to be commited to pass.
+The modification check also requires the changes to be committed to pass.
 
 ## Unit and Manual Tests
 We use [Vitest](https://vitest.dev/) for unit testing TypeScript code

--- a/packages/manual/src/developer/contributing/translation.md
+++ b/packages/manual/src/developer/contributing/translation.md
@@ -28,7 +28,7 @@ To add new translations, follow these steps:
       button.ok: "好的"
     ```
 3. Go to the `localization` package (`cd packages/localization`)
-4. Run the `edit` task and pass in your file
+4. Run the `edit` task and pass in your file:
    ```
    task edit -- path/to/your/file
    ```

--- a/packages/manual/src/developer/extensions.md
+++ b/packages/manual/src/developer/extensions.md
@@ -1,5 +1,5 @@
 # Extensions
 
 ```admonish todo
-The extension system and documentation is WIP. This page is a placeholder
+The extension system and documentation is WIP. This page is a placeholder.
 ```

--- a/packages/manual/src/developer/index.md
+++ b/packages/manual/src/developer/index.md
@@ -1,7 +1,7 @@
 # Developer Manual
 
 This section is highly technical and only intended for people 
-who work with or are interested in the IST simulator as a developer.
+who work with, or are interested in, the IST simulator as a developer.
 For example:
   - Contributing to the project
   - Building extensions for the simulator

--- a/packages/manual/src/faq.md
+++ b/packages/manual/src/faq.md
@@ -4,13 +4,13 @@
 Inventory Slot Transfer, or IST, is a glitch in BOTW that desyncs the number of 
 items you have in the inventory and number of items the game *thinks you have*.
 For more details, check out [history of the app](./history.md) and an 
-[overview of the glitch](./ist/index.md)
+[overview of the glitch](./ist/index.md).
 
-## I am new to IST, How do I use this tool?
+## I am new to IST; how do I use this tool?
 You definitely don't need to be a master of IST to find this tool useful.
-If you are looking at a speedrun setup made by someone else. 
-You can view the setup in the tool as a step-by-step guide for how to perform
-the glitch. If you are a glitch hunter or is interested in investigating
+If you are looking at a speedrun setup made by someone else, 
+you can view the setup in the tool as a step-by-step guide for how to perform
+the glitch. If you are a glitch hunter or are interested in investigating
 the glitch in more details, the [user manual](./user/index.md) has everything
 you need to unlock the full potential of the simulator.
 
@@ -18,7 +18,7 @@ In any case, it might be helpful to understand [the basic concepts](./ist/basics
 of IST to get started.
 
 ## I can't understand IST, but I still want to speedrun
-Don't worry. IST is very complicated. Most people (including WR holders!)
+Don't worry; IST is very complicated. Most people (including WR holders!)
 don't fully understand the glitch. This is exactly why this tool exists.
 
 If your goal is to do the setup in a speedrun, what most people do is 
@@ -29,8 +29,8 @@ Many categories also have tutorials made for the IST section. For example,
 made by Player 5.
 
 ## I just want to play with IST as a casual player
-Be cautious to use IST with your casual file, as effect of IST can persist
-in saves and may cause the saves to be corrupted or not-loadable.
+Be cautious to use IST with your casual file, as effects of IST can persist
+in saves and may cause the saves to be corrupted or non-loadable.
 
 There are generalized guides for how to achieve certain things with IST
 in a casual file (for example, <skyb>999 korok seeds</skyb>). You can follow
@@ -48,18 +48,18 @@ is executed in a sandbox orchestrated by the simulator app. This means the simul
 might even be possible to support use cases that are not discovered yet.
 
 ## Can I contribute?
-Certainly! If you see some bugs and want to take a shot on fixing them,
+Certainly! If you see some bugs and want to take a shot at fixing them,
 feel free to open a PR on GitHub. If you want to add features, please discuss
 with me first. A decent level of programming knowledge is needed.
 
-Most of this project is open-source and use publicly available data of the game.
-However, some parts require you own a copy of the game to develop.
+Most of this project is open-source and use publicly-available data of the game.
+However, some parts require that you own a copy of the game to develop.
 
 Please refer to the [contributing guide](./developer/contributing.md) for more information.
 
 ```admonish note
-If you goal is to add extra functionality, you might be able to do that through
-an extension, See [Extensions](./developer/extensions.md)
+If your goal is to add extra functionality, you might be able to do that through
+an extension. See [Extensions](./developer/extensions.md).
 ```
 ```admonish note
 If you are not familiar with programming, you can still contribute to the test suite
@@ -67,7 +67,7 @@ by providing your (complicated) scripts as test cases. These test cases help ens
 future updates to the simulator don't introduce bugs. See [Snapshot Testing](./developer/contributing/testing.md#snapshot-tests).
 
 If you are not able to generate the snapshot locally, simply make sure the output for every step
-is correct in the App, then open a PR with just the new `.txt` script file
+is correct in the App, then open a PR with just the new `.txt` script file.
 ```
 
 

--- a/packages/manual/src/ist/dic.md
+++ b/packages/manual/src/ist/dic.md
@@ -5,12 +5,12 @@
 In the game, durability is stored as a *fixed-point* integer,
 with `1` being `0.015`. For example, a weapon with durability `10` has the internal
 value of `1000`. In the case of corruption, the durability is transferred
-from an equipment not to another equipment, but to an item. The value
+from an equipment - not to another equipment, but to an item. The value
 then becomes the count of items. This is very useful, since
 you can get a LOT of items from an equipment with relatively low durability
 that's easy to get.
 
-This form of corruption was previously only possible using *Memory Storage*
+This form of corruption was previously only possible using *Memory Storage* -
 another very complex glitch with a lengthy setup. With IST, however,
 Inventory Corruption is much easier, hence the name *Direct Inventory Corruption*.
 
@@ -61,7 +61,7 @@ after a reload*.
 
 Remember that reloading a save also causes durability to be applied?
 This means inventory corruption automatically happens after a reload.
-All the player needs to do to exploit this is to transfer specific items
+All the player needs to do to exploit this, is to transfer specific items
 to desync the `GameData` in the way so that equipped items are aligned
 to the item to corrupt. This is why different IST setups exist to corrupt
 different things in different speedruns.
@@ -70,8 +70,8 @@ different things in different speedruns.
 This is also why it is important to follow the setup to unequip/equip
 certain items before reloading, because the equipped item slot is what is
 used for corruption. To be exact, the durability of the *last equipped slot*
-is transfered into the *first equipped slot* in *both* `Visible Inventory`
-and `GameData`
+is transferred into the *first equipped slot* in *both* `Visible Inventory`
+and `GameData`.
 ```
 
 ## Aligning the Items
@@ -123,7 +123,7 @@ put (sort) the item into the correct category when you get something:
    - The list is sorted from lowest value to highest
 
 ```admonish info
-This type of sort is referred to as a *stable sort* using a *predicate* that only compares the category of the items
+This type of sort is referred to as a *stable sort* using a *predicate* that only compares the category of the items.
 ```
 
 The sorting itself cannot achieve the unsorted state, but *absence of sort* can.
@@ -141,8 +141,3 @@ faster to not break as many slots. This is why some setups require dropping some
 immediately pick them up again. While picking up the weapons, the `mCount` never surpasses
 `1`, causing the weapons you pick up remain at the end of the inventory.
 ```
-
-
-
-
-

--- a/packages/manual/src/ist/index.md
+++ b/packages/manual/src/ist/index.md
@@ -42,14 +42,14 @@ The inventory that you see when opening the inventory in-game - the `Visible Inv
 stored as a (doubly-)linked list. In this list representation, items in different categories
 are "concatenated" into the same list. For example, in normal inventory order,
 the list may have all the weapons, followed by all the bows, followed by
-all the arrows, etc, and in the end are all the key items. In one page
+all the arrows, etc, and at the end are all the key items. In one page
 of the item in the in-game UI, the top-left corner is first,
 and it follows row-major order (i.e. the item in row 1 column 2 is after the item
 in row 1 column 1 in the list), and the bottom-right corner is last,
 followed by the upper-left corner item of the next page.
 
 ```admonish info
-The empty spaces and empty tabs in the inventory do not take space in the list
+The empty spaces and empty tabs in the inventory do not take space in the list.
 ```
 
 The items are also stored at the same time in `GameData`, which is the game's flag system.
@@ -72,18 +72,19 @@ as long as mCount is no longer 0, you will be able to access the inventory again
 
 ## Why is it called IST - The main mechanism
 The huge number of glitches that are derived from IST all rely on the core
-mechanism - trasnferring slots, which is how the glitch got its name.
+mechanism - transferring slots, which is how the glitch got its name.
 
 This all happens when the inventory is `Reload`-ed, either when loading a save,
 or restoring the inventory from a quest that takes away your items (i.e.
 Trial of the Sword, Stranded on Eventide, or any of the Blight Refights).
+
 When restoring the inventory, the game needs to do 3 things:
 
 1. Delete all of your current items in `Visible Inventory`.
 2. Load the data of the inventory to restore into `GameData`.
    - In case of reloading a save, it is loaded from the save file.
    - In case of quests, it is already stored in `GameData`.
-3. Add the items `GameData` one by one into the `Visible Inventory`.
+3. Add the items in `GameData` one-by-one into the `Visible Inventory`.
 
 The magic happens in step 1. Since `mCount` is less than the actual number
 of items, the game does not fully delete all the items in inventory.

--- a/packages/manual/src/ist/pe.md
+++ b/packages/manual/src/ist/pe.md
@@ -10,11 +10,11 @@ the actual implementation in the game.
 This section is WIP and may contain inaccurate information. If you see any issues,
 or want to improve this section,
 please edit [this file](https://github.com/Pistonite/botw-ist/tree/main/packages/manual/src/ist/pe.md)
-and open a Pull Request
+and open a Pull Request.
 ```
 
 **Prompt Entanglement**, or PE, is a glitch that allows you to apply
-a prompt (like "Equip", "Drop", "Hold", etc) to from one item to another item
+a prompt (like "Equip", "Drop", "Hold", etc) from one item to another item
 that is not supposed to have that prompt. For example:
 
 - Holding a Food (only Materials are normally holdable)
@@ -23,8 +23,9 @@ that is not supposed to have that prompt. For example:
 
 ## Invalid Star Tab
 ```admonish note
-IST refers to Inventory Slot Transfer in contexts pertaining Invalid Star Tab.
+IST refers to Inventory Slot Transfer in contexts pertaining to Invalid Star Tab.
 ```
+
 To activate PE, the first step is to activate a state known as **Invalid Star Tab**.
 This is a state that allows the cursor (the box that highlights which item is 
 currently selected in the inventory) to go to the "Key Items" icon.
@@ -34,7 +35,7 @@ items in a category that you have not discovered. For example,
 have a material *without picking up any material*.
 
 At first this seems impossible. However, the catch is "picking up" - 
-You can obtain items without picking them up with IST. In an Invalid Star Tab
+you can obtain items without picking them up with IST. In an Invalid Star Tab
 setup, there are 3 general steps:
 
 - Save with the tab you want to use undiscovered
@@ -80,18 +81,19 @@ together [a spreadsheet](https://docs.google.com/spreadsheets/d/1j0UM0kIGs74DKkK
 to active each slot.
 ```
 
-When Cursor Glitch is active, you can keep it active by move tabs in groups
-of 3 (tap right stick right 3 times, or left 3 times), without pausing too long
+When Cursor Glitch is active, you can keep it active by moving tabs in groups
+of 3 (tap right-stick right 3 times, or left 3 times), without pausing too long
 between them. Pausing while not on a multiple of 3 tabs from where the slot
 is activated will reset the cursor's position, losing the glitched state.
 
 ## Capturing the Prompt
-What the Cursor Glitch enables is that we can now move the cursor to another item,
-with the inventory screen still "thinks" we are on the original item,
+What the Cursor Glitch enables, is that we can now move the cursor to another item,
+while the inventory screen still "thinks" we are on the original item,
 so it opens the prompt of the original item when we trigger it.
 
 When we trigger the prompt (pressing `A`), the prompt used
-comes from the item that is currently showing description on the screen:
+comes from the item that is currently showing the description on the screen:
+
 ```
       |- you are looking at this page
       v
@@ -105,9 +107,9 @@ comes from the item that is currently showing description on the screen:
 When moving tabs in groups of 3, the Cursor Glitch causes the prompt
 to be *locked*, meaning it will not update the name/description of the item.
 You can force update it by going to the System screen and back (pressing `R` then `L`).
-This is often refered to as "resetting" or "capturing" the prompt.
+This is often referred to as "resetting" or "capturing" the prompt.
 
-With the prompt locked, you can now move the cursor to 3 tabs left or right,
+With the prompt locked, you can now move the cursor 3 tabs left or right,
 which will change which item the cursor is on, but will not update the prompt.
 Now, you can press `A` to trigger and use the prompt.
 
@@ -119,8 +121,7 @@ In general, these are the steps to do any PE setup:
 
 ```admonish tip
 Since you can only keep the glitch by moving tabs in groups of 3,
-this means PE can only be used between 2 items that are multiple of 3 tabs apart
-(i.e. have 2 other tabs between the source and target items)
+this means PE can only be used between 2 items that are multiple of 3 tabs apart (i.e. have 2 other tabs between the source and target items).
 ```
 
 ## Applications
@@ -182,7 +183,7 @@ The change equip action will cause a durability update, which transfers the dura
 
 ```admonish tip
 Note that unlike durability transfer with Menu Overload, you do not need to use the equipment
-to update the durability. This is because the desync acheived by PE is the exact opposite of Menu Overload:
+to update the durability. This is because the desync achieved by PE is the exact opposite of Menu Overload:
 
 - Menu Overload desyncs by switching the equipment in the Inventory, but not in overworld
 - PE desyncs by switching the equipment in the overworld, but not in the inventory
@@ -195,4 +196,3 @@ to update the durability.
 You can also use this to unequip the One-hit Obliterator, which is more
 consistent than using Menu Overload. After performing the steps above,
 you will be able to unequip the OHO from the DPad Quick Menu.
-

--- a/packages/manual/src/ist/wmc.md
+++ b/packages/manual/src/ist/wmc.md
@@ -10,18 +10,18 @@ During this corruption:
 - The `Health Recover` value of the cooked item becomes the `Value` of the modifier.
   - For regular food, this value is the number of quarter-hearts recovered.
     Between 0 and 120.
-  - For hearty food, this is the number of yellow hearts
+  - For hearty food, this is the number of yellow hearts.
 - The `Sell Price` value of the cooked item becomes the `Type` of the modifier.
   - The `Type` is a bit-flag, so WMC can enable multiple modifiers on the same equipment.
   - See [`actWeapon.h`](https://github.com/zeldaret/botw/blob/master/src/Game/Actor/actWeapon.h)
-    for values for each modifier type
+    for values for each modifier type.
 
 ```admonish info
-You will see [Prompt Entanglment (PE)](./pe.md) often brought up together with WMC.
+You will see [Prompt Entanglement (PE)](./pe.md) often brought up together with WMC.
 This is because WMC relies on the data from a cooked item, and you can only get
 a very limited subset of possible cook data values by cooking with normal ingredients.
 PE allows cooking with unusual ingredients, which is required to get some modifier value/flag.
-However, WMC and PE are 2 separated glitches, and neither is required to perform the other.
+However, WMC and PE are 2 separate glitches, and neither is required to perform the other.
 ```
 
 ## Base Mechanism
@@ -30,7 +30,7 @@ WMC is possible because:
 1. The data for cooked item and the data for modifier is in the same memory
    location for each item. i.e. if the item is a food, then the data is used
    as cooked data, and if the item is a weapon, then it is used as modifier data.
-   - This is only true for `Visible Inventory`, not `GameData`
+   - This is only true for `Visible Inventory`, not `GameData`.
 2. The data for cooked item is added separately from the item itself.
 
 In step 2, the cook data is added after adding the cook item, and the game
@@ -39,7 +39,7 @@ the data.
 
 Therefore, a WMC setup typically involves:
 1. Making sure the *last added item* is the weapon to receive the corrupted modifier
-2. Make the cooked item that *donates* the data failed to load while
+2. Make the cooked item that *donates* the data fail to load while
    the *last added item* is still the weapon, transferring the data to the weapon
 
 Note that #2 essentially means that *no item should be loaded between the weapon
@@ -49,23 +49,23 @@ Depending on *how* these 2 conditions are satisfied, the WMC setups
 can be further categorized.
 
 ```admonish info
-In general, WMC can refer to any of the case when the *last added item*
+In general, WMC can refer to any of the cases where the *last added item*
 is not the item that is *supposed* to receive the data.
 
 You can technically corrupt any item in `Visible Inventory`,
 but only Equipments and Foods will have the data saved to `GameData`.
 
 It is not possible to transfer modifier between Weapons, because unlike
-food, the data for weapons are added in the same step as the item itself (condition 2 from above)
+food, the data for weapons are added in the same step as the item itself (condition 2 from above).
 ```
 
 Currently, WMC is only possible when reloading the inventory from `GameData` (for example
 when reloading a save). This is because there is no known way to trigger adding a cook item
-during normal game play while at the same time make it so the cook item doesn't get added
-succesfully.
+during normal game play while at the same time making it so the cook item doesn't get added
+successfully.
 
 ## Food Limit
-Using the food limit was one of the first method to WMC. This WMC setup
+Using the food limit was one of the first methods to WMC. This WMC setup
 uses the fact that during a reload, any food after the first 60 will not load (under normal circumstances).
 This can be achieved by transferring 60 food into a save with a weapon, followed by the donor meal.
 
@@ -81,11 +81,11 @@ reload
 
 The step-by-step explanation:
 
-1. Note that in the save, the items are 1 `hammer` and the donor meal, these are what will be added during reload
-2. Note that we are transferring 60 `dubious-food`
-3. During the reload, the `hammer` loads in first
+1. Note that in the save, the items are 1 `hammer` and the donor meal: these are what will be added during reload.
+2. Note that we are transferring 60 `dubious-food`.
+3. During the reload, the `hammer` loads in first.
 4. When loading the donor meal, since there are already 60 food, it fails to load.
-5. Since the last added item was the `hammer`, the data from the meal is transferred to the hammer
+5. Since the last-added item was the `hammer`, the data from the donor meal is transferred to the hammer.
 
 ```admonish info
 The main drawback for this method is that it requires 60 food and 60 broken slots. Getting 60 broken slots
@@ -101,7 +101,7 @@ But wait! *What if that's exactly what we wanted?* Instead of transferring the m
 we can do 2 transfers:
 1. Using the Food Limit method, transfer the data from the donor meal to a *Stackable* food (i.e. a roasted/baked/frozen food)
 2. Using [Direct Inventory Corruption](./dic.md), corrupt the food value to >=500
-3. When loading a stackable item slot, if the value being loaded plus the value of the item in the inventory is greater than 999,
+3. When loading a stackable item slot, if the value being loaded - plus the value of the item in the inventory - is greater than 999,
    the stack will fail to load (this is why we need >=500 in the previous step)
 4. When the stackable food fails to load, it can trigger WMC
 
@@ -133,7 +133,7 @@ reload
 ```admonish info
 As you can see, this method can work with a minimum of 1 broken slots, which is a big improvements over 60 broken slots.
 In speedruns, typically we use more broken slots anyway to corrupt other stuff and for duplicating food to quickly
-reach the 60 food required for the first transfer
+reach the 60 food required for the first transfer.
 ```
 
 ## The Nullptr Exploit
@@ -148,13 +148,13 @@ data of the previous food!
 ```admonish info
 This can happen because in the `GameData`, the cook data and the item themselves are not stored in the same array:
 
-- The item name array has 420 strings, one for each item
+- The item name array has 420 strings, one for each item.
 - The cook data array has 60 elements, one for each food.
 
-When the Nullptr Exploit is triggered, the counter for the item array increments, but not the cook data array
+When the Nullptr Exploit is triggered, the counter for the item array increments, but not the cook data array.
 ```
 
-Using this exploit, 60 food is no longer required. However, this exploit is pretty tricky to trigger,
+Using this exploit, 60 food is no longer required. However, this exploit is pretty tricky to trigger;
 this is because `mLastAddedItem` is only `nullptr` before any item is added (with one exception being the Master Sword).
 
 ## Master Sword (MSWMC)
@@ -170,23 +170,23 @@ The condition for this trigger is somewhat complicated:
    - 3 and 4 usually means the save has a broken Master Sword
 
 ```admonish tip
-In one sentence, this means to "transfer a Master Sword into a save with a broken Master Sword"
+In one sentence, this means to "transfer a Master Sword into a save with a broken Master Sword".
 ```
 
-When all of the above conditions are met, last added item is set to `nullptr`, enabling the exploit.
+When all of the above conditions are met, the last-added item is set to `nullptr`, enabling the exploit.
 
 The whole setup would be:
 1. Enable the exploit as described above
 2. In the same reload, load a food unsuccessfully, without loading any item in between
    - This uses the exploit described in the previous section to cause the reuse of cook data
-3. Now any food that load after will have the data that's supposed to be on the food before it
+3. Now any food that loads after will have the data that's supposed to be on the food before it
 4. Continue the Stackable Food Limit setup
 
 ## Travel Medallion (TMWMC)
 
 ```admonish todo
 This section is WIP and may contain inaccurate information. If you see any issues,
-or want to improve this section, please create a Pull Request
+or want to improve this section, please create a Pull Request.
 ```
 
 The Travel Medallion is added in the Master Trials DLC. Unlike any other DLC items, it gets removed
@@ -197,10 +197,10 @@ This can be used to trigger the Nullptr Exploit:
    (using [Unsorted Inventory](./dic.md#unsorted-inventory-and-forward-corruption) )
 2. Close the game and uninstall the DLC
    - If you have physical game without DLC + digital game with DLC, this can be done by ejecting the Virtual Game Card
-   - Otherwise, follow the steps on this [Nintendo Support Ariticle](https://en-americas-support.nintendo.com/app/answers/detail/a_id/22433/~/how-to-redownload-nintendo-switch%26nbsp%3B2-or-nintendo-switch-digital-content)
+   - Otherwise, follow the steps on this [Nintendo Support Article](https://en-americas-support.nintendo.com/app/answers/detail/a_id/22433/~/how-to-redownload-nintendo-switch%26nbsp%3B2-or-nintendo-switch-digital-content)
 3. Reload the save, setup IST again to transfer some food to make the food fail to load
 4. Reload the save again, the Travel Medallion will not load as the first item since DLC is uninstalled, and the next food will fail to load because of the transfer
-5. Now any food that load after will have the data that's supposed to be on the food before it
+5. Now any food that loads after will have the data that's supposed to be on the food before it
 6. Continue the Stackable Food Limit setup
 
 Unlike MSWMC, Travel Medallion does not set last added item to `nullptr`, so it has very limited usefulness.
@@ -209,11 +209,11 @@ Unlike MSWMC, Travel Medallion does not set last added item to `nullptr`, so it 
 ## Zelda Notes (ZNWMC)
 ```admonish todo
 This section is WIP and may contain inaccurate information. If you see any issues,
-or want to improve this section, please create a Pull Request
+or want to improve this section, please create a Pull Request.
 ```
 
 ```admonish warning
-This method has not be verified. It is only theorized based on reverse engineering of version 1.8.0 of the Switch 1 Edition
+This method has not be verified. It is only theorized based on reverse engineering of version 1.8.0 of the Switch 1 Edition.
 ```
 
 Zelda Notes is an item exclusive to the Nintendo Switch 2 Edition. When you uninstall NS2E,
@@ -223,9 +223,6 @@ it gets removed from your inventory and can be used to trigger the Nullptr Explo
 2. Close the game and uninstall NS2E
    - If you have the physical NS2E Game Card and the NS1E game (physical or digital), this can be done by removing the physical NS2E Game Card (then inserting the NS1E Game Card if you have a physical copy)
    - If you only have the physical NS2E Game Card, this is not possible.
-   - Otherwise, follow the steps on this [Nintendo Support Ariticle](https://en-americas-support.nintendo.com/app/answers/detail/a_id/22433/~/how-to-redownload-nintendo-switch%26nbsp%3B2-or-nintendo-switch-digital-content)
+   - Otherwise, follow the steps on this [Nintendo Support Article](https://en-americas-support.nintendo.com/app/answers/detail/a_id/22433/~/how-to-redownload-nintendo-switch%26nbsp%3B2-or-nintendo-switch-digital-content)
      to download the game without NS2E
 3. The rest is similar to TMWMC
-
-
-

--- a/packages/manual/src/user/commands.md
+++ b/packages/manual/src/user/commands.md
@@ -7,7 +7,7 @@ Clicking on a command will take you to the corresponding documentation page.
 
 | Command | Description |
 |-|-|
-| <skyb>:accurately-simulate</skyb> | Turn off optimizations that may be inaccurate |
+| [<skyb>:accurately-simulate</skyb>](../action/get.md#performance) | Turn off optimizations that may be inaccurate |
 | [<skyb>!add-slot</skyb>](../action/low_level.md) | Adding a new slot to the inventory list by editing memory, bypassing all checks |
 | [<skyb>!break</skyb>](../action/low_level.md) | Edit memory to simulate generating Broken Slots |
 | [<skyb>buy</skyb>](../action/get.md) | Buying items |
@@ -30,7 +30,7 @@ Clicking on a command will take you to the corresponding documentation page.
 | <skyb>open-inventory</skyb> | Alias for <skyb>pause</skyb> |
 | <skyb>:overworld</skyb> | Specify the next action to be performed in the overworld |
 | <skyb>pause</skyb> | Open the inventory |
-| <skyb>:pause-during</skyb> | Open the inventory during certain operations |
+| [<skyb>:pause-during</skyb>](../action/get.md#pause-on-item-text-boxes) | Open the inventory during certain operations |
 | [<skyb>:per-use</skyb>](../action/overworld.md) | Change the durability to decrease per use |
 | [<skyb>pick-up</skyb>](../action/get.md) | Pick up an item from the ground |
 | [<skyb>!remove</skyb>](../action/low_level.md) | Forcefully remove items from inventory, even non-interactable ones |

--- a/packages/manual/src/user/custom_image.md
+++ b/packages/manual/src/user/custom_image.md
@@ -1,7 +1,7 @@
 # Custom Image
 
 ```admonish todo
-Custom Image functionality is WIP. Please reach out to me if you want to play with it
+Custom Image functionality is WIP. Please reach out to me if you want to play with it.
 ```
 
 When running into code outside the normal inventory logic using glitches
@@ -10,9 +10,9 @@ because it does not contain the full game to be able to execute setups
 that involves code outside of the normal inventory code.
 
 BUT, the simulator is *capable* of executing the whole game's code
-if it is given access. This is refer to as the **Full Mode** or **Custom Image Mode**.
+if it is given access. This is referred to as the **Full Mode** or **Custom Image Mode**.
 To do this, you need to create a BlueFlame image (a `.bfi` file) from the 
-game files
+game files.
 
 ## Create Image
 To create the image, you need the following things:
@@ -31,6 +31,7 @@ The `env` block must be at the beginning, before any lines and comments.
 Empty lines are allowed before the block.
 
 The `env` block should contain one `<key> = <value>` per line. Here is an example:
+
 ```skybook
 '''env
 image = 1.5
@@ -43,7 +44,7 @@ pmdm-addr      = 0x0000003456789ab0
 '''
 ```
 ```admonish note
-The numeric values must be hexadecimal, the leading `0x` is optional
+The numeric values must be hexadecimal; the leading `0x` is optional.
 ```
 ```admonish note
 If a value is invalid, it's equivalent to that value being not specified.
@@ -56,7 +57,7 @@ Allowed values are `1.5` and `1.6`.
 ```admonish warning
 Currently, only `1.5` is supported. `1.6` is recognized but
 not supported. Newer versions won't be recognized by either
-the simulator or uking-relocate
+the simulator or `uking-relocate`.
 ```
 
 The rest of the keys are optional. If not specified, the simulator will use the internal default values.
@@ -85,7 +86,7 @@ One of the following shorthand is recommended:
 | ver 2.0| `dlc-2`, `ver2.0`, `master-trials`  |
 | ver 3.0| `dlc-3`, `ver3.0`, `champions-ballad` |
 
-Invalid DLC version specifier defaults to `ver3.0`
+Invalid DLC version specifier defaults to `ver3.0`.
 
 A Region Address must be a hexadecimal string aligned to `0x100000`,
 the most significant 6 hex-digits must be all `0`.
@@ -121,4 +122,3 @@ when uploading the custom image.
 You can open the
 3-dot menu on the top of the app and select `Delete Custom Image`.
 This clears the custom image file that is stored in your local browser.
-

--- a/packages/manual/src/user/index.md
+++ b/packages/manual/src/user/index.md
@@ -3,7 +3,7 @@
 ```admonish info
 This section covers how to use the Simulator App. While not
 required, understanding IST itself could make it easier to understand
-some of the concepts here. You can read about IST [here](../ist/index.md)
+some of the concepts here. You can read about IST [here](../ist/index.md).
 ```
 
 ## How the Simulator works
@@ -11,7 +11,7 @@ The **Simulator** runs on a **Script**, which is a text file that contains
 **Commands** for the simulator. Usually, the commands are the **steps** or **actions**
 you perform in the IST setup.
 
-Here's an example of such script, each line is a command.
+Here's an example of such script; each line is a command.
 ```skybook
 get 1 pot-lid 1 apple 1 slate 1 glider
 equip Shield
@@ -44,7 +44,7 @@ The simulator app has 3 editing modes:
 You can switch the mode anytime in the top-left corner of the app.
 
 ```admonish warning
-When switching to `Auto Saved`, your locally saved script will be overwritten with whatever
+When switching to `Auto Saved`, your locally-saved script will be overwritten with whatever
 script that's currently in the script editor!
 
 If you accidentally overwrite your local script and you need it, you can still recover it

--- a/packages/manual/src/user/overworld_system.md
+++ b/packages/manual/src/user/overworld_system.md
@@ -12,12 +12,12 @@ the actors that are involved in inventory glitches:
 
 ## Material Drop Limit
 In the game, you can drop at most `10` items on the ground at a time.
-When you drop the `11`-th item, the least recent dropped item will despawn.
+When you drop the `11`-th item, the least-recent dropped item will despawn.
 This limit is simulated by the `Overworld` system in the following way:
 
 - When dropping material with the <skyb>drop</skyb> command, or auto-dropped
   from a smuggled state, it gets added to the list of items on the ground
-- The least recently dropped items will be removed from the list, until
+- The least-recently dropped items will be removed from the list, until
   there are at most 10 items on the ground
 - The removed items are not deleted immediately. You will see `Will despawn`
   in the tooltip text of the item in the simulator UI.
@@ -42,15 +42,15 @@ Then:
 - If you <skyb>pick-up 5 apples</skyb> right after, there will be `10` apples
   left on the ground, and `5` are added to the inventory.
 - If you <skyb>pause</skyb>, there will still be `15` apples on the ground,
-  since you could <skyb>unpause</skyb> and pick them up
+  since you could <skyb>unpause</skyb> and pick them up.
 - If you <skyb>get 3 bananas</skyb>, the despawning items will now be deleted,
   and there will be `10` apples left on the ground. This is because it's unlikely
-  the apples are still there after you pick up some other item
+  the apples are still there after you pick up some other item.
 
 ## Resetting the Overworld
 
 ```admonish todo
-This functionality is WIP
+This functionality is WIP.
 ```
 
 In a long IST setup, there might be times where you travel between different
@@ -63,7 +63,5 @@ can simulate this:
     - The <skyb>!loading-screen</skyb> supercommand can be used to simulate regenerating the game stage
       with a loading screen, if none of the action commands match your needs.
 - The <skyb>!reset-ground</skyb> supercommand can be used to delete all items
-  on the ground. Use this if you are travelling to another area without a loading
-  screen
-
-
+  on the ground. Use this if you are traveling to another area without a loading
+  screen.

--- a/packages/manual/src/user/screen_system.md
+++ b/packages/manual/src/user/screen_system.md
@@ -13,7 +13,7 @@ when you open a screen, which can be helpful when optimizing and verifying IST s
 
 ```admonish tip
 The simulator UI has a little icon next to the "Visible Inventory" title
-to indicate which screen you are currently on
+to indicate which screen you are currently on.
 ```
 
 ## Game State
@@ -31,7 +31,6 @@ Please report it on [GitHub](https://github.com/Pistonite/botw-ist/issues)
 if the simulator crashes on a step that you don't think is supposed to crash in game.
 
 You can also view the detail of the crash in the `Crash Viewer` Extension.
-
 ```
 
 Whenever the game is closed in the middle of a simulation (either closed manually or crashed), it will not automatically
@@ -49,7 +48,7 @@ While in game, there are 4 screens that are simulated:
   - You can get/drop items
   - ... all the other things you can do in the overworld
 - `Inventory`:
-  - When pause the game with the `+` button
+  - When you pause the game with the `+` button
   - Player can interact with items in the inventory
 - `Shop Selling`:
   - When talking to a shop owner to sell items
@@ -58,7 +57,7 @@ While in game, there are 4 screens that are simulated:
   - When talking to Beedle or some other NPC to buy items
   - Player can select from a list of items to buy
 
-The `Screen` system works like a state machine, when an action needs a certain
+The `Screen` system works like a state machine; when an action needs a certain
 screen, it will try to transition to that screen state if possible, and display
 an error if it couldn't. The transition looks something like this:
 

--- a/packages/manual/src/user/syntax.md
+++ b/packages/manual/src/user/syntax.md
@@ -29,7 +29,7 @@ hold 2 apples drop
 hold 2 apples; drop
 ```
 
-In general, the syntax is case sensitive. Although some features like item search is case-insensitive,
+In general, the syntax is case-sensitive. Although some features like item search is case-insensitive,
 it's recommended to keep everything lower-case, unless upper-case is needed (for example
 when specifying actor name or GDT flag name).
 
@@ -67,6 +67,6 @@ Generally, `key`s are `kebab-case` words, and `value`s can be one of:
   like `<Foo>`.
 
 ```admonish tip
-Generally, the 3 string formats are all accept and can be interchangeable.
+Generally, the 3 string formats are all accepted and can be interchangeable.
 In some cases however, the formats can have different meanings.
 ```

--- a/packages/manual/src/user/syntax_comment.md
+++ b/packages/manual/src/user/syntax_comment.md
@@ -4,7 +4,7 @@ Comments and Notes are text in the script that don't affect
 the output of the command.
 
 ## Comments
-Comments are lines that start with `#` or `//`. They are completely ignored
+Comments are lines that start with `#` or `//`. They are completely ignored.
 
 ```skybook
 # This is a comment
@@ -13,11 +13,11 @@ Comments are lines that start with `#` or `//`. They are completely ignored
 
 ```admonish tip
 In the script editor, you can use the hotkey `Ctrl + /` to quick toggle
-selected lines between commented/uncommented
+selected lines between commented/uncommented.
 ```
 
 ## Block Literals
-Block Literal is a multi-line block that starts and ends with `'''` (triple single-quotes)
+Block Literal is a multi-line block that starts and ends with `'''` (triple single-quotes).
 
 ```skybook
 '''
@@ -29,7 +29,7 @@ It can have multiple lines
 
 Addtionally, a block literal can have a `tag`, which is a string after the `'''`
 that starts the block. For example, the `note` tag can be used to add
-notes to blocks of commands, which can be viewed in the `Notes` extension
+notes to blocks of commands, which can be viewed in the `Notes` extension.
 
 ```skybook
 '''note
@@ -40,5 +40,5 @@ drop all shields
 ```
 
 ```admonish info
-The `Notes` feature is not implemented yet
+The `Notes` feature is not implemented yet.
 ```

--- a/packages/manual/src/user/syntax_item.md
+++ b/packages/manual/src/user/syntax_item.md
@@ -13,7 +13,7 @@ e.g. <skyb>2 apples 3 bananas</skyb>
 
 When there is only one item in the list, and the amount is `1`, you can omit the amount. For example <skyb>get 1 apple</skyb> can
 be shortened to just <skyb>get apple</skyb>. However, amount is required 
-when the list contains more than one item name/category
+when the list contains more than one item name/category.
 ```
 
 The syntax could be used in **3** scenarios, depending on the command:
@@ -22,7 +22,7 @@ The syntax could be used in **3** scenarios, depending on the command:
    - The amount must be a number, not keywords like <skyb>all</skyb>.
    - The name must be an item, not category.
    - The metadata is used to *describe* extra properties of the item.
-   - Generally used by commands for *adding* items, such as <skyb>get</skyb>
+   - Generally used by commands for *adding* items, such as <skyb>get</skyb>.
 
 2. `INFINITE_ITEM_LIST`
    - The amount could be a number or the keyword <skyb>infinite</skyb>.
@@ -35,9 +35,9 @@ The syntax could be used in **3** scenarios, depending on the command:
      - The keyword <skyb>all</skyb>
      - In the form <skyb>all but X</skyb>, where `X` is a number.
    - The name could be an item or a category.
-   - The metadata is used to *match* from items in some existing list (such as your inventory)
+   - The metadata is used to *match* from items in some existing list (such as your inventory).
    - Generally used by commands that *targets* some item, such as <skyb>hold</skyb> and <skyb>eat</skyb>.
-   - [Position properties](#selecting-from-multiple-matches) can be used
+   - [Position properties](#selecting-from-multiple-matches) can be used.
 
 
 ## Amount
@@ -48,7 +48,7 @@ since you can eat from corrupted food or decrease armor value/durability by eati
 however, the amount means how many *slots* for unstackable items.
 
 In `CONSTRAINED_ITEM_LIST`, you can use 2 special amount forms: <skyb>all</skyb> and <skyb>all but</skyb>:
-- <skyb>all</skyb> will repeatly find the item and perform the action on the item, until the item cannot be found.
+- <skyb>all</skyb> will repeatedly find the item and perform the action on the item, until the item cannot be found.
 - <skyb>all but X</skyb> will first count the total number of times the action can be performed,
   then perform the action `count - X` times. How the total number is counted depends on the command,
   similar to the eat vs sell situation mentioned earlier.
@@ -83,10 +83,10 @@ You can specify the name of the item in 4 ways:
 3. By `Localization` - 
    If English is not your preferred language, you can specify items by their localized name using a quoted-string.
    For example, <skyb>"espadon royal"</skyb> or <skyb>"王族双手剑"</skyb>.
-   - The string is fuzzy-searched in all languages
-   - To lock the language, prepend the query with the language and a colon, for example, <skyb>"fr:espadon royal"</skyb>
-     this could be useful if the query is short, and is matching in another language that you didn't expect.
-   - Localized search only applies to items, not commands (like <skyb>get</skyb>, <skyb>hold</skyb>, etc)
+   - The string is fuzzy-searched in all languages.
+   - To lock the language, prepend the query with the language and a colon, for example, <skyb>"fr:espadon royal"</skyb>.
+     This could be useful if the query is short, and is matching in another language that you didn't expect.
+   - Localized search only applies to items, not commands (like <skyb>get</skyb>, <skyb>hold</skyb>, etc).
 4. By `Category` - 
    When selecting items from inventory or some other list of items, you can
    also use a category in the place of the item name to match the first item of that category.
@@ -95,16 +95,16 @@ You can specify the name of the item in 4 ways:
    where it doesn't matter which weapons are picked up.
 
 ```admonish info
-  See [token](https://github.com/Pistonite/botw-ist/blob/d5812037f4909eeb48cb2ba666dccdb672563cc4/packages/parser/src/syn/token.rs#L119) for possible category values
+  See [token](https://github.com/Pistonite/botw-ist/blob/d5812037f4909eeb48cb2ba666dccdb672563cc4/packages/parser/src/syn/token.rs#L119) for possible category values.
 ```
 
 ## Metadata
 The [Meta Syntax](./syntax.md#meta-syntax) is used to specify additional properties for the item:
 
-- In `FINITE_ITEM_LIST`, it is used to specify extra data on the item to be added
+- In `FINITE_ITEM_LIST`, it is used to specify extra data on the item to be added.
   - For example, <skyb>get pot-lid[durability=1]</skyb> gets a new <skyb>pot-lid</skyb> with `1` durability
 - In `CONSTRAINED_ITEM_LIST`, it is used to specify extra data used to match the item to operate on.
-  - For example, if you are multiple `pot-lids`, <skyb>drop pot-lid[durability=1]</skyb> targets the one with exactly `1` durability.
+  - For example, if you have multiple `pot-lids`, <skyb>drop pot-lid[durability=1]</skyb> targets the one with exactly `1` durability.
 
 Available metadata properties:
 
@@ -116,7 +116,7 @@ Available metadata properties:
 | `ingr` | | (`string`) Set the ingredient of the cooked-food. The string must be an item identifier (see above). The property can be specified multiple times to add multiple ingredients. |
 | `level`| | (`int`) Sets the level of the effect for cooked-food |
 | `life-recover`| `hp`, `modpower` | (`int`) Sets the number of quarter-hearts cooked-food recovers, or value of a weapon modifier |
-| `modifier` | `modtype` | (`int` or `string`) Set weapon modifier. <br><br>**Cannot be used to set food effect type**. <br><br> Integer values are the same as `price`. String values can be specified multiple times to build up the weapon modifier. <br><br> When used for matching, if only one modifier is specified, it will match any modifier flags that includes the specified one (i.e. other modifiers are allowed), if more than one bit is specified, the modifier flag must match exactly.<br> See [Weapon Modifiers](../generated/constants.md#weapon-modifiers) for possible values |
+| `modifier` | `modtype` | (`int` or `string`) Set weapon modifier. <br><br>**Cannot be used to set food effect type**. <br><br> Integer values are the same as `price`. String values can be specified multiple times to build up the weapon modifier. <br><br> When used for matching, if only one modifier is specified, it will match any modifier flag that includes the specified one (i.e. other modifiers are allowed), if more than one bit is specified, the modifier flag must match exactly.<br> See [Weapon Modifiers](../generated/constants.md#weapon-modifiers) for possible values |
 | `price` | |(`int`) Sets the price of the cooked-food. This can also be used to set multiple weapon modifiers as a bit mask |
 | `star` | | (`int`) Armor star (upgrade) number, valid range is `0-4`, inclusive. <br>Note that this is syntactic sugar to change the name of the item, as armor with different star numbers are different items. |
 | `time` | | (`int`) Sets the duration of the food effect in seconds |
@@ -164,8 +164,8 @@ eat 2 apple[tab=0, slot=3]
 ```
 
 ```admonish note
-- If the slot selected by position has a different item, you will receive an error
-- When using `row` and `col`, they must be specified after `category` or `tab`
+- If the slot selected by position has a different item, you will receive an error.
+- When using `row` and `col`, they must be specified after `category` or `tab`.
 ```
 
 ```admonish warning

--- a/packages/parser/src/cir/enum_name.rs
+++ b/packages/parser/src/cir/enum_name.rs
@@ -3,7 +3,7 @@
 //! by commands in the right context.
 //!
 //! When parsing, `-`, `-`, and spaces (` `) are ignored.
-//! So for example `resist-cold` is the same as `resistcold`
+//! So for example `resist-cold` is the same as `resistcold`.
 
 /// Parse cook effect name for the `effect` meta property for items
 #[rustfmt::skip]


### PR DESCRIPTION
1. Adds some punctuation to help sentences break apart for readability.
2. Modifies some punctuation where sentences should have continued: "...is known as `Arrowless Offset`. which requires..." to "...is known as `Arrowless Offset`, which requires...".
3. Minor grammar fixes.
4. Fixes a few typos; replaces a few `if` with `whether` so the sentence afterward doesn't 
    > Change flag values in GameData (GDT), such as number of upgrade slots,
    > ~~if~~ *whether* a tab is discovered, and quest flags.
5. Adds trailing periods.
    - This is not terribly consistent, as I didn't want to add periods to the end of ALL bulleted lists across all files, but I did want to add to bullet items where other nearby bullets ended in periods already.
6. Added links (such as manual/src/user/commands.md) to some keywords.

I notice that many lines are wrapped at roughly column 80, while others are either drastically shorter or longer. I did not wrap my changes, nor did I rearrange text from nearby lines, so help keep the diff smaller.

If you would prefer that I resubmit a PR with smaller changes, or "punctuation" fixes in separate commits from "typo" fixes, let me know.