### PR TITLE
chore: bump runtime state cache to 512

### DIFF
--- a/packages/runtime/src/sim/runtime.rs
+++ b/packages/runtime/src/sim/runtime.rs
@@ -28,7 +28,7 @@ impl Runtime {
         Self {
             executor,
             initial_process: Mutex::new(None),
-            state_cache: Mutex::new(LruCache::new(256)),
+            state_cache: Mutex::new(LruCache::new(512)),
         }
     }
 


### PR DESCRIPTION
closes #214 